### PR TITLE
Update execution plan checks for already running jobs with the same j…

### DIFF
--- a/source/Jobbr.Server.ForkedExecution.Tests/JobExecutorOnPlanChangedTests.cs
+++ b/source/Jobbr.Server.ForkedExecution.Tests/JobExecutorOnPlanChangedTests.cs
@@ -81,7 +81,7 @@ namespace Jobbr.Server.ForkedExecution.Tests
             executor.OnPlanChanged(new List<PlannedJobRun>(new[] { fakeJobRun1.PlannedJobRun, fakeJobRun2.PlannedJobRun }));
 
             // Wait
-            var didStart2Jobs = this.ProgressChannelStore.WaitForStatusUpdate(updatesFromAllJobs => updatesFromAllJobs.Count == 2 && updatesFromAllJobs.All(kvp => kvp.Value.Contains(JobRunStates.Starting)), 5000);
+            var didStart2Jobs = this.ProgressChannelStore.WaitForStatusUpdate(updatesFromAllJobs => updatesFromAllJobs.Count == 2 && updatesFromAllJobs.All(kvp => kvp.Value.Contains(JobRunStates.Starting) && kvp.Value.Count == 1), 5000);
 
             // Test
             var statesPerJobRun = string.Join("\n", this.ProgressChannelStore.AllStatusUpdates.Select(u => $"- JobRun #{u.Key}, States: {string.Join(",", u.Value)}"));

--- a/source/Jobbr.Server.ForkedExecution/Execution/ForkedJobExecutor.cs
+++ b/source/Jobbr.Server.ForkedExecution/Execution/ForkedJobExecutor.cs
@@ -106,7 +106,7 @@ namespace Jobbr.Server.ForkedExecution.Execution
                 }
 
                 // Add only new
-                var toAdd = newPlan.Where(newItem => this.plannedJobRuns.All(existingItem => existingItem.Id != newItem.Id)).ToList();
+                var toAdd = newPlan.Where(newItem => this.plannedJobRuns.All(existingItem => existingItem.Id != newItem.Id) && this.activeContexts.All(c => c.JobRunId != newItem.Id)).ToList();
                 this.plannedJobRuns.AddRange(toAdd);
                 hadChanges += toAdd.Count;
 

--- a/source/Jobbr.Server.ForkedExecution/Execution/IJobRunContext.cs
+++ b/source/Jobbr.Server.ForkedExecution/Execution/IJobRunContext.cs
@@ -4,6 +4,8 @@ namespace Jobbr.Server.ForkedExecution.Execution
 {
     public interface IJobRunContext
     {
+        long JobRunId { get; }
+
         event EventHandler<JobRunEndedEventArgs> Ended;
 
         void Start();

--- a/source/Jobbr.Server.ForkedExecution/Execution/JobRunContext.cs
+++ b/source/Jobbr.Server.ForkedExecution/Execution/JobRunContext.cs
@@ -37,6 +37,8 @@ namespace Jobbr.Server.ForkedExecution.Execution
             this.serviceMessageParser = new ServiceMessageParser();
         }
 
+        public long JobRunId => this.jobRunInfo.Id;
+
         public event EventHandler<JobRunEndedEventArgs> Ended;
 
         public void Start()


### PR DESCRIPTION
I guess, there is still a very small timeframe, where multiple executions can happen:
In the ContextOnEnded method, the context gets removed from the activeContexts, but the message handler for the job (which removes the job from the currentPlan in the DefaultScheduler) is executed later.
Maybe it is a possiblity, to keep the contexts after finishing in memory with a timestamp and remove them later, for example in the OnPlanChanged method.