### PR TITLE
Fix services injection

### DIFF
--- a/source/Jobbr.Server.ForkedExecution.Tests/BackChannelWebHostTests.cs
+++ b/source/Jobbr.Server.ForkedExecution.Tests/BackChannelWebHostTests.cs
@@ -1,12 +1,12 @@
-﻿using System;
+﻿using Jobbr.Server.ForkedExecution.BackChannel;
+using Jobbr.Server.ForkedExecution.Tests.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SimpleInjector;
+using System;
 using System.Net.Http;
 using System.Net.Sockets;
 using System.Threading.Tasks;
-using Jobbr.Server.ForkedExecution.BackChannel;
-using Jobbr.Server.ForkedExecution.Tests.Infrastructure;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Jobbr.Server.ForkedExecution.Tests
 {
@@ -29,8 +29,8 @@ namespace Jobbr.Server.ForkedExecution.Tests
             {
                 BackendAddress = "http://localhost:" + TcpPortHelper.NextFreeTcpPort()
             };
-            
-            var host = new BackChannelWebHost(_loggerFactory, new ServiceCollection(), forkedExecutionConfiguration);
+
+            var host = new BackChannelWebHost(_loggerFactory, new Container(), forkedExecutionConfiguration);
             host.Start();
 
             // Act
@@ -48,8 +48,8 @@ namespace Jobbr.Server.ForkedExecution.Tests
             {
                 BackendAddress = "http://localhost:" + TcpPortHelper.NextFreeTcpPort()
             };
-            
-            var host = new BackChannelWebHost(_loggerFactory, new ServiceCollection(), forkedExecutionConfiguration);
+
+            var host = new BackChannelWebHost(_loggerFactory, new Container(), forkedExecutionConfiguration);
 
             host.Start();
             host.Stop();
@@ -77,8 +77,8 @@ namespace Jobbr.Server.ForkedExecution.Tests
             {
                 BackendAddress = "http://localhost:" + TcpPortHelper.NextFreeTcpPort()
             };
-            
-            var host = new BackChannelWebHost(_loggerFactory, new ServiceCollection(), forkedExecutionConfiguration);
+
+            var host = new BackChannelWebHost(_loggerFactory, new Container(), forkedExecutionConfiguration);
 
             host.Start();
             host.Dispose();
@@ -107,8 +107,8 @@ namespace Jobbr.Server.ForkedExecution.Tests
             {
                 BackendAddress = "http://localhost:" + TcpPortHelper.NextFreeTcpPort()
             };
-            
-            var host = new BackChannelWebHost(_loggerFactory, new ServiceCollection(), forkedExecutionConfiguration);
+
+            var host = new BackChannelWebHost(_loggerFactory, new Container(), forkedExecutionConfiguration);
 
             // Act
             // Assert

--- a/source/Jobbr.Server.ForkedExecution.Tests/EndpointTests.cs
+++ b/source/Jobbr.Server.ForkedExecution.Tests/EndpointTests.cs
@@ -1,17 +1,17 @@
-﻿using System;
+﻿using Jobbr.ComponentModel.Execution;
+using Jobbr.ComponentModel.Execution.Model;
+using Jobbr.Server.ForkedExecution.BackChannel;
+using Jobbr.Server.ForkedExecution.Tests.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SimpleInjector;
+using System;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using Jobbr.ComponentModel.Execution;
-using Jobbr.ComponentModel.Execution.Model;
-using Jobbr.Server.ForkedExecution.BackChannel;
-using Jobbr.Server.ForkedExecution.Tests.Infrastructure;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Jobbr.Server.ForkedExecution.Tests
 {
@@ -153,9 +153,9 @@ namespace Jobbr.Server.ForkedExecution.Tests
                 BackendAddress = _configBackendAddress
             };
 
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton<IJobRunInformationService>(new JobRunInfoServiceMock(_fakeStore));
-            serviceCollection.AddSingleton<IJobRunProgressChannel>(_channelFakeStore);
+            var serviceCollection = new Container();
+            serviceCollection.RegisterInstance<IJobRunInformationService>(new JobRunInfoServiceMock(_fakeStore));
+            serviceCollection.RegisterInstance<IJobRunProgressChannel>(_channelFakeStore);
 
             var webHost = new BackChannelWebHost(new NullLoggerFactory(), serviceCollection, config);
 

--- a/source/Jobbr.Server.ForkedExecution.Tests/ExecutorRuntimeIntegrationTests.cs
+++ b/source/Jobbr.Server.ForkedExecution.Tests/ExecutorRuntimeIntegrationTests.cs
@@ -1,18 +1,18 @@
-﻿using System;
+﻿using Jobbr.ComponentModel.Execution;
+using Jobbr.ComponentModel.Execution.Model;
+using Jobbr.Server.ForkedExecution.BackChannel;
+using Jobbr.Server.ForkedExecution.TestRunner.TestJobs;
+using Jobbr.Server.ForkedExecution.Tests.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SimpleInjector;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
-using Jobbr.ComponentModel.Execution;
-using Jobbr.ComponentModel.Execution.Model;
-using Jobbr.Server.ForkedExecution.BackChannel;
-using Jobbr.Server.ForkedExecution.TestRunner.TestJobs;
-using Jobbr.Server.ForkedExecution.Tests.Infrastructure;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Jobbr.Server.ForkedExecution.Tests
 {
@@ -25,9 +25,9 @@ namespace Jobbr.Server.ForkedExecution.Tests
 
             new ConfigurationValidator(new NullLoggerFactory()).Validate(config);
 
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton<IJobRunInformationService>(JobRunInformationService);
-            serviceCollection.AddSingleton<IJobRunProgressChannel>(ProgressChannelStore);
+            var serviceCollection = new Container();
+            serviceCollection.RegisterInstance<IJobRunInformationService>(JobRunInformationService);
+            serviceCollection.RegisterInstance<IJobRunProgressChannel>(ProgressChannelStore);
 
             var backChannelHost = new BackChannelWebHost(new NullLoggerFactory(), serviceCollection, config);
             backChannelHost.Start();
@@ -62,7 +62,7 @@ namespace Jobbr.Server.ForkedExecution.Tests
 
             // Act
             ManualTimeProvider.AddSecond();
-            executor.OnPlanChanged(new List<PlannedJobRun>(new [] { fakeRun.PlannedJobRun }));
+            executor.OnPlanChanged(new List<PlannedJobRun>(new[] { fakeRun.PlannedJobRun }));
 
             // Assert
             var hasConnected = ProgressChannelStore.WaitForStatusUpdate(allUpdates => allUpdates[fakeRun.Id].Contains(JobRunStates.Connected), 3000);
@@ -134,7 +134,7 @@ namespace Jobbr.Server.ForkedExecution.Tests
             // Arrange
             var config = GivenAMinimalConfiguration();
             config.JobRunnerExecutable = "Jobbr.Server.ForkedExecution.TestRunner.exe";
-            
+
             GivenAStartedBackChannelHost(config);
             var executor = GivenAStartedExecutor(config);
 
@@ -188,7 +188,7 @@ namespace Jobbr.Server.ForkedExecution.Tests
 
             var fakeRun = JobRunFakeTuples.CreateFakeJobRun(DateTime.UtcNow);
             fakeRun.JobRunInfo.Type = "JobWithParameters";
-            
+
             // Act
             ManualTimeProvider.AddSecond();
             executor.OnPlanChanged(new List<PlannedJobRun>(new[] { fakeRun.PlannedJobRun }));
@@ -343,7 +343,7 @@ namespace Jobbr.Server.ForkedExecution.Tests
             var config = GivenAMinimalConfiguration();
             config.JobRunnerExecutable = "Jobbr.Server.ForkedExecution.TestEcho.exe";
             config.JobRunDirectory = tempDir;
-            config.AddJobRunnerArguments = infos => new List<KeyValuePair<string, string>>(new []{ new KeyValuePair<string, string>("argument1", "value1"), });
+            config.AddJobRunnerArguments = infos => new List<KeyValuePair<string, string>>(new[] { new KeyValuePair<string, string>("argument1", "value1"), });
 
             GivenAStartedBackChannelHost(config);
             var executor = GivenAStartedExecutor(config);

--- a/source/Jobbr.Server.ForkedExecution/Jobbr.Server.ForkedExecution.csproj
+++ b/source/Jobbr.Server.ForkedExecution/Jobbr.Server.ForkedExecution.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="SimpleInjector" Version="5.4.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Fixed SimpleInjector.ActivationException: The constructor of type BackChannelWebHost contains the parameter with name 'serviceCollection' and type IServiceCollection, but IServiceCollection is not registered. For IServiceCollection to be resolved, it must be registered in the container.